### PR TITLE
show hide link_targed depending on #cn_see_more

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -18,8 +18,10 @@
 	$( '#cn_see_more' ).change( function () {
 	    if ( $( this ).is( ':checked' ) ) {
 		$( '#cn_see_more_opt' ).slideDown( 'fast' );
+		$('#cn_link_target').closest('tr').slideDown('fast');
 	    } else {
 		$( '#cn_see_more_opt' ).slideUp( 'fast' );
+		$('#cn_link_target').closest('tr').slideUp('fast');
 	    }
 	} );
 


### PR DESCRIPTION
Great plugin, but I was bit puzzled while I have found a setting for "link target" and no "link" to relate it with. I have added a show/hide for that setting as well depending on value of #cn_see_more.