### PR TITLE
Style issue with v1.44 and media query for mobile

### DIFF
--- a/css/front.css
+++ b/css/front.css
@@ -13,6 +13,10 @@
 .cookie-notice-container {
     padding: 10px;
     text-align: center;
+    width: 100%;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
 }
 
 .cn-top {
@@ -104,4 +108,12 @@
     -moz-transition: background-position 0.1s linear;
     -o-transition: background-position 0.1s linear;
     transition: background-position 0.1s linear;
+}
+
+@media all and (max-width: 900px) {
+    
+    .cookie-notice-container span {
+        display: block;
+    }
+    
 }


### PR DESCRIPTION
Version 1.44 has the width of .cookie-notice-container set to 100%. This results in this div being larger than the screen size in some cases. Adding box-sizing resolves this. 

On mobile/tablet, having the buttons appear across two lines isn't aesthetically pleasing when one button is to the right of the text. Adding a media query to force the buttons onto a new line resolves this.