### PR TITLE
Fix option 'cookie_notice_version' did not delete.

### DIFF
--- a/cookie-notice.php
+++ b/cookie-notice.php
@@ -791,8 +791,10 @@ class Cookie_Notice {
 	 * Deactivate the plugin.
 	 */
 	public function deactivation() {
-		if ( $this->options['general']['deactivation_delete'] === 'yes' )
+		if ( $this->options['general']['deactivation_delete'] === 'yes' ) {
 			delete_option( 'cookie_notice_options' );
+			delete_option( 'cookie_notice_version' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fix option 'cookie_notice_version' did not delete on deactivate.

However, please add option to delete everything on uninstall instead of deactivate.