### PR TITLE
Add aria-label to main HTML container

### DIFF
--- a/cookie-notice.php
+++ b/cookie-notice.php
@@ -700,11 +700,12 @@ class Cookie_Notice {
 				'see_more'			=> $this->options['general']['see_more'],
 				'see_more_opt'		=> $this->options['general']['see_more_opt'],
 				'link_target'		=> $this->options['general']['link_target'],
+				'aria_label'		=> __( 'Cookie Notice', 'cookie-notice' )
 			) );
 
 			// message output
 			$output = '
-			<div id="cookie-notice" role="banner" class="cn-' . ($options['position']) . ($options['css_style'] !== 'none' ? ' ' . $options['css_style'] : '') . '" style="color: ' . $options['colors']['text'] . '; background-color: ' . $options['colors']['bar'] . ';">'
+			<div id="cookie-notice" role="banner" class="cn-' . ($options['position']) . ($options['css_style'] !== 'none' ? ' ' . $options['css_style'] : '') . '" style="color: ' . $options['colors']['text'] . '; background-color: ' . $options['colors']['bar'] . ';" aria-label="' . ($options['aria_label']) . '">'
 				. '<div class="cookie-notice-container"><span id="cn-notice-text">'. $options['message_text'] .'</span>'
 				. '<a href="#" id="cn-accept-cookie" data-cookie-set="accept" class="cn-set-cookie ' . $options['button_class'] . ($options['css_style'] !== 'none' ? ' ' . $options['css_style'] : '') . '">' . $options['accept_text'] . '</a>'
 				. ($options['refuse_opt'] === 'yes' ? '<a href="#" id="cn-refuse-cookie" data-cookie-set="refuse" class="cn-set-cookie ' . $options['button_class'] . ($options['css_style'] !== 'none' ? ' ' . $options['css_style'] : '') . '">' . $options['refuse_text'] . '</a>' : '' )


### PR DESCRIPTION
I am running an ADA accessibility scanning tool called Site Improve. It has flagged the cookie notice to have the role of banner but it is considered empty. To bein compliance, I the container needs to have
 
`aria-label="Cookie Notice"`