### PR TITLE
notice width is wider than screen fixed.

### DIFF
--- a/css/front.css
+++ b/css/front.css
@@ -1,6 +1,7 @@
 #cookie-notice {
 	position: fixed;
-	min-width: 100%;
+	min-width: 99%%;
+	max-width:100%;
 	height: auto;
 	z-index: 100000;
 	font-size: 13px;


### PR DESCRIPTION
on mobile phones, cookie-bar being wider than screen caused issues with the layout, causing a horizontal scroll bar. this  issue is annoying. 
enforcing the cookie-bar width to exactly like the window width might solve the issue.  